### PR TITLE
fix(src) : check if the timeout value is passed is positive value

### DIFF
--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/function/support/HandlerFunctionAdapter.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/function/support/HandlerFunctionAdapter.java
@@ -73,12 +73,14 @@ public class HandlerFunctionAdapter implements HandlerAdapter, Ordered {
 	 * should time out. In Servlet 3, the timeout begins after the main request
 	 * processing thread has exited and ends when the request is dispatched again
 	 * for further processing of the concurrently produced result.
-	 * <p>If this value is not set, the default timeout of the underlying
-	 * implementation is used.
+	 * <p>If this value is not set or negative value is passed, the default timeout of 
+	 * the underlying implementation is used.
 	 * @param timeout the timeout value in milliseconds
 	 */
 	public void setAsyncRequestTimeout(long timeout) {
-		this.asyncRequestTimeout = timeout;
+		if(timeout >= 0) {
+			this.asyncRequestTimeout = timeout;
+		}
 	}
 
 	@Override


### PR DESCRIPTION
- Validate the timeout value passed to setAsyncRequestTimeout is positive value.
- Avoid setting negative value. If negative value is passed then set it to default timeout.